### PR TITLE
change StyledH2 font-size to 4rem on laptop, change StyledH2 text in …

### DIFF
--- a/src/SharedComponents/StyledH2.js
+++ b/src/SharedComponents/StyledH2.js
@@ -13,7 +13,7 @@ const H2Component = styled.h2`
   font-size: 3rem;
 }
 @media ${device.laptop} {
-  font-size: 3rem;
+  font-size: 4rem;
 }
 `;
 

--- a/src/pages/Home/About.js
+++ b/src/pages/Home/About.js
@@ -2,7 +2,7 @@ import React from 'react';
 import styled from "styled-components";
 import farmers from './images/farmers.jpg';
 import Wrapper from "../../SharedComponents/ComponentWrapper";
-import StyledH1 from "../../SharedComponents/StyledH1";
+import StyledH2 from "../../SharedComponents/StyledH2";
 
 const FarmerIllustration = styled.img`
   display: block;
@@ -23,9 +23,9 @@ const AboutText = styled.p`
 const About = () => {
   return (
     <Wrapper id="about" maxWidth={"600px"} positionRelative={true}>
-      <StyledH1 colorIsGrey={true} centered={true}>
-        About the Farmers
-      </StyledH1>
+      <StyledH2 colorIsGrey={true} centered={true}>
+        The Farmers
+      </StyledH2>
       <FarmerIllustration
         src={`${farmers}`}
         width="1200"

--- a/src/pages/Home/Process.js
+++ b/src/pages/Home/Process.js
@@ -72,8 +72,7 @@ const Process = () => {
   return (
     <ComponentWrapper id="process">
       <StyledH2>
-        
-        Our Process
+        The Process
       </StyledH2>
       <ProcessWrapper>
         {processes.map(process => (


### PR DESCRIPTION
# Purpose
- Make sure that StyledH2 is equivalent of 64px font-size on laptop+ device sizes

# Validating
- Check font size of figma design with StyledH2 when on laptop size device

# Background Text
- For some reason I didn't set laptop's font-size to 4rem

# Follow-On Questions
- none

# Extra Release Steps
- none