### PR TITLE
Add colorblock to shared products

### DIFF
--- a/src/SharedComponents/ComponentWrapper.js
+++ b/src/SharedComponents/ComponentWrapper.js
@@ -12,6 +12,8 @@ const StyledWrapper = styled.div`
     props.id === "process" ? "0px auto -3% auto" : "0px auto 120px auto"};
   padding: ${props =>
     props.id === "process" ? "200px 0 12% 0" : "200px 0 140px 0"};
+  border-top: ${props => props.hasTopBottomBorders ? "1px solid black" : "none"};
+  border-bottom: ${props => props.hasTopBottomBorders ? "1px solid black" : "none"};
   ${({ backgroundColor }) =>
     backgroundColor &&
     `
@@ -25,13 +27,14 @@ const StyledWrapper = styled.div`
     `}
 `;
 
-const ComponentWrapper = ({maxWidth, children, id, backgroundColor}) => {
+const ComponentWrapper = ({maxWidth, children, id, backgroundColor, hasTopBottomBorders}) => {
 
   return (
     <StyledWrapper
       maxWidth={maxWidth}
       id={id}
       backgroundColor={backgroundColor}
+      hasTopBottomBorders={hasTopBottomBorders}
     >{children}</StyledWrapper>
   );
 }

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -10,7 +10,7 @@ import StyledH5 from "./StyledH5";
 const ProductContainer = styled.div`
   display: block;
   width: 35%;
-  margin-bottom: 20px;
+  margin-bottom: 40px;
   :hover h5 {
     color: #e3be42;
   }
@@ -24,6 +24,7 @@ const ProductContainer = styled.div`
   }
   @media ${device.tablet} {
     width: 25%;
+    margin-bottom: 20px;
   }
 `;
 
@@ -59,8 +60,7 @@ const createProduct = (product, clearHeroImg, updateQuantityButton) => {
       </ImageContainer>
       <StyledH5 centered={true}> {product.title.toUpperCase()} </StyledH5>
       <p className="info">
-        5ml bottle <br />
-        <strong>${product.variants.edges[0].node.price}</strong>
+        ${product.variants.edges[0].node.price}
       </p>
     </ProductLink>
   );

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -5,21 +5,13 @@ import PropTypes from "prop-types";
 import styled from "styled-components";
 import { device } from "../utils/devices";
 import * as CartActionCreators from "../state/actions/cart";
+import StyledH5 from "./StyledH5";
 
 const ProductContainer = styled.div`
   display: block;
   width: 35%;
   margin-bottom: 20px;
-  .title {
-    margin: 0;
-    font-size: 1em;
-    line-height: 1.25em;
-    font-weight: normal;
-    color: #787878;
-    text-decoration: none;
-    text-align: center;
-  }
-  :hover .title {
+  :hover h5 {
     color: #e3be42;
   }
   .info {
@@ -28,7 +20,7 @@ const ProductContainer = styled.div`
     line-height: 1.167em;
     font-weight: normal;
     text-align: center;
-    color: #666666;
+    color: black;
   }
   @media ${device.tablet} {
     width: 25%;
@@ -65,7 +57,7 @@ const createProduct = (product, clearHeroImg, updateQuantityButton) => {
           alt={`${product.description}`}
         />
       </ImageContainer>
-      <h3 className="title"> {product.title.toUpperCase()} </h3>
+      <StyledH5 centered={true}> {product.title.toUpperCase()} </StyledH5>
       <p className="info">
         5ml bottle <br />
         <strong>${product.variants.edges[0].node.price}</strong>

--- a/src/SharedComponents/Products.js
+++ b/src/SharedComponents/Products.js
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom';
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import ComponentWrapper from "./ComponentWrapper";
+import StyledH2 from "./StyledH2";
 
 import Product from './Product';
 import { connect } from "react-redux";
@@ -15,9 +16,6 @@ const ProductsContainer = styled.div`
   position: relative;
 `;
 
-const StyledH2 = styled.h2`
-  color: #787878;
-`;
 
 const ExploreShopLink = styled(Link)`
   display: block;
@@ -25,13 +23,13 @@ const ExploreShopLink = styled(Link)`
   min-width: 145px;
   max-width: 300px;
   margin: 30px auto 0 auto;
-  padding: 5px;
+  padding: 10px 5px;
   color: #e3be42;
-  border: 1px solid #e3be42;
+  border: 2px solid #e3be42;
   border-radius: 10px;
   text-align: center;
-  font-size: 1em;
-  font-weight: normal;
+  font-size: 1.225em;
+  font-weight: 300;
   text-decoration: none;
   &:hover {
     background-color: #e3be42;
@@ -42,7 +40,7 @@ const ExploreShopLink = styled(Link)`
 const Products = ({products, title}) => {
 
   return (
-    <ComponentWrapper>
+    <ComponentWrapper hasTopBottomBorders={true}>
       <StyledH2> {title} </StyledH2>
       <ProductsContainer>
         {products

--- a/src/SharedComponents/Products.js
+++ b/src/SharedComponents/Products.js
@@ -37,10 +37,10 @@ const ExploreShopLink = styled(Link)`
   }
 `;
 
-const Products = ({products, title}) => {
+const Products = ({products, title, hasTopBottomBorders}) => {
 
   return (
-    <ComponentWrapper hasTopBottomBorders={true}>
+    <ComponentWrapper hasTopBottomBorders={hasTopBottomBorders}>
       <StyledH2> {title} </StyledH2>
       <ProductsContainer>
         {products

--- a/src/SharedComponents/StyledH5.js
+++ b/src/SharedComponents/StyledH5.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import styled from "styled-components";
+
+const H5Component = styled.h5`
+  margin-bottom: 5px;
+  padding: 0;
+  font-weight: bold;
+  font-size: 1.313rem;
+  color: #2e2e2e;
+  text-align: ${props => props.centered ? "center" : "left" };
+`;
+
+const StyledH5 = ({children, centered}) => {
+
+  return (
+    <H5Component centered={centered}>{children}</H5Component>
+  );
+}
+
+export default StyledH5;

--- a/src/SharedComponents/StyledH5.js
+++ b/src/SharedComponents/StyledH5.js
@@ -1,13 +1,22 @@
 import React from 'react';
 import styled from "styled-components";
+import { device } from "../utils/devices";
 
 const H5Component = styled.h5`
   margin-bottom: 5px;
   padding: 0;
+  font-size: .925rem;
   font-weight: bold;
-  font-size: 1.313rem;
   color: #2e2e2e;
   text-align: ${props => props.centered ? "center" : "left" };
+  @media ${device.tablet} {
+  font-size: 1.125rem;
+    
+  }
+  @media ${device.laptop} {
+  font-size: 1.313rem;
+
+  }
 `;
 
 const StyledH5 = ({children, centered}) => {

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -12,7 +12,7 @@ import RecipeSection from './RecipeSection'
 const Home = () =>
     <PageWrapper>
       <WelcomeSection />
-      <Products title={"Featured Products"}/>
+      <Products title={"Featured Products"} hasTopBottomBorders={true}/>
       <About />
       <PhotoSection />
       <Process />

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -12,7 +12,7 @@ import RecipeSection from './RecipeSection'
 const Home = () =>
     <PageWrapper>
       <WelcomeSection />
-      <Products title={""}/>
+      <Products title={"Featured Products"}/>
       <About />
       <PhotoSection />
       <Process />


### PR DESCRIPTION
# Purpose
Originally purpose was to add color block to products, but this pivoted to re-styling the Products page slightly due to it being difficult to get background of product photos to be transparent

New goal was to: 
1. create top/bottom borders for Products section on Home.js (but not other pages)
2. update font styles for product
3. update font styles for ExploreTheShop link

# Validating
- Make sure that top and bottom borders only appear on home.js and no other pages
- Check that products layout doesn't break on following pages: home, product, checkout, recipes

# Background Context
- Result of kayla's redesign

# Follow-On Questions
- Perhaps it was overkill to adjust ComponentWrapper to accept an additional prop just to control for this one use-case where the Products need a top and bottom border. May be able to refactor this.

# Extra Release Steps
- none