### PR TITLE
refactor createCheckoutButton to create checkoutId upon clicking chec…

### DIFF
--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -37,10 +37,13 @@ const Layout = ({
       : console.log("checkout doesn't exist");
   };
 
+  // if checkout exists, clear checkout in state if checkout was completed
+  if (checkoutId) {
+    clearCheckoutIfCompleted();
+  }
+
   // if products haven't been fetched, fetch them
   if (!products.length) {
-    // if checkout has been completed, clear checkout in state
-    clearCheckoutIfCompleted();
     // populate state with products and articles from shopify
     fetchShopifyProducts();
     fetchShopifyArticles();

--- a/src/root.js
+++ b/src/root.js
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 
 import * as serviceWorker from './serviceWorker';
-import { Reducer1 } from './state/App';
+import { Reducer1 } from './state/app';
 import App from './App';
 import { saveToLocalStorage, getFromLocalStorage } from "../src/state/localStorage";
 import thunk from "redux-thunk";


### PR DESCRIPTION
# Purpose
- simplify Checkout page by refactoring createCheckoutButton to create checkoutId only when checkout button is clicked, thus allowing us to remove componentDidMount() on checkout page

# Validating
make sure that checkout flow works in following conditions:
1. Normal checkout process: add items to cart, click checkout, complete checkout
2. Make sure that checkout is cleared if checkout was completed, and you return back to site
3. Make sure that if checkout button is clicked, but user goes back to edit cart and then re-click checkout button, checkout process still works as normal, and uses new updated item and quantities

# Background Context
- While attempting to improve my skill in using promises, I wanted to refactor the promise within createCheckoutButton to avoid using a nested function for "client.checkout.addLineItems(checkoutId, lineItemsToAdd)"
- Unfortunately, I can't wrap my head around how to refactor this to avoid a nested promise, which I know is a bad practice

# Follow-On Questions
- What is the correct way to un-nest this promise?:
```
const createIdAndCheckout = () =>
    client.checkout.create()
      .then(checkout => {
        updateCheckoutId(checkout.id)
        return checkout.id
      })
      .then(checkoutId =>
        client.checkout.addLineItems(checkoutId, lineItemsToAdd)
          .then(checkout => {
            window.location.href = checkout.webUrl;
          })
          .catch(error =>
            console.log("Error creating ID and Checking Out: ", error)
          )
      );
```

# Extra Release Steps
- none