### PR TITLE
Show collection on shared products

### DIFF
--- a/src/SharedComponents/Products.js
+++ b/src/SharedComponents/Products.js
@@ -44,7 +44,7 @@ const Products = ({products, title, hasTopBottomBorders}) => {
       <StyledH2> {title} </StyledH2>
       <ProductsContainer>
         {products
-          .filter(product => product.availableForSale)
+          .filter(product => product.collections.edges[0].node.handle === "featured-products")
           .map(product => (
             <Product key={product.id} product={product} />
           ))}

--- a/src/root.js
+++ b/src/root.js
@@ -4,7 +4,7 @@ import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 
 import * as serviceWorker from './serviceWorker';
-import { Reducer1 } from './state/App';
+import { Reducer1 } from './state/app';
 import App from './App';
 import { saveToLocalStorage, getFromLocalStorage } from "../src/state/localStorage";
 import thunk from "redux-thunk";

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -37,11 +37,14 @@ export const fetchShopifyArticlesAction = () => {
 
 // Build a custom products query using the unoptimized version of the SDK
 const productsQuery = client.graphQLClient.query((root) => {
-  root.addConnection('products', {args: {first: 4}}, (product) => {
+  root.addConnection('products', {args: {first: 20}}, (product) => {
     product.add('title');
     product.add('descriptionHtml');
     product.add('handle');
     product.add('availableForSale');
+    product.addConnection("collections", {args: {first: 2}}, collection => {
+      collection.add("handle");
+    });
     product.addConnection("metafields", {args: {first: 2}}, metafield => {
       metafield.add("key")
       metafield.add("value");


### PR DESCRIPTION
# Purpose
- only show products that belong to 'featured-products' collection on SharedComponents/Products

# Validating
- other products that do not belong to this collection should only show up on the shop page, and nowhere else

# Background Context
- Previously all products show on SharedComponents/Products, but in reality there are more products in the shop than we will want to show in this component, so we need a way to limit it to only items that belong to a specific collection

# Follow-On Questions
- Improvement to make would be to filter the edges of collections to look for the "featured-products" collection, in the event they ever use collections for something else.

# Extra Release Steps
- none