### PR TITLE
Revert "adjust Product key to product.node.id"

### DIFF
--- a/src/SharedComponents/FeaturedProducts.js
+++ b/src/SharedComponents/FeaturedProducts.js
@@ -57,7 +57,7 @@ const Products = ({ title, hasTopBottomBorders }) => {
       <ProductsContainer>
         {featuredProducts
         .map(product => (
-          <Product key={product.node.id} product={product} />
+          <Product key={product.id} product={product} />
         ))}
       </ProductsContainer>
       <ExploreShopLink to="/shop">Explore the Shop</ExploreShopLink>


### PR DESCRIPTION
Reverts dbridenbeck/whidbey-herbal#84

Reverting because this branch, and the branch "refactor-shop-page-shopify-fetching" ultimately lead to the product page being broken if navigated to directly.

In lieu of pulling shopify data in the components that request them (products.js, shop.js) I am going to continue fetching for shopify data within Layout for now.

When I hope to refactor this code to request shopify data within the components that request them, take a look at the branch "refactor-shop-page-shopify-fetching" for where I left off before realizing that this broke product pages when navigated to directly.