### PR TITLE
Revert "Refactor shared component products to featured products"

### DIFF
--- a/src/Layout/Header.js
+++ b/src/Layout/Header.js
@@ -169,6 +169,7 @@ export class Header extends PureComponent {
   }
 
   render() {
+    console.log("props in header is: ", this.props)
   return (
     <>
       {this.createNavBar()}

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -76,10 +76,10 @@ const createProduct = (product, clearHeroImg, updateQuantityButton) => {
 };
 
 // begin component
-const Product = ({product: {node}, clearHeroImg, updateQuantityButton}) => {
+const Product = ({product, clearHeroImg, updateQuantityButton}) => {
   return (
     <ProductContainer>
-      {createProduct(node, clearHeroImg, updateQuantityButton)}
+      {createProduct(product, clearHeroImg, updateQuantityButton)}
     </ProductContainer>
   );
 };

--- a/src/SharedComponents/Products.js
+++ b/src/SharedComponents/Products.js
@@ -1,12 +1,12 @@
-import React, {useState} from 'react';
+import React from 'react';
 import { Link } from 'react-router-dom';
 import styled from "styled-components";
 import PropTypes from "prop-types";
-import { client } from "../plugins/shopify.js";
 import ComponentWrapper from "./ComponentWrapper";
 import StyledH2 from "./StyledH2";
+
 import Product from './Product';
-import { queryFeaturedProductsCollection } from '../state/fetchShopifyData';
+import { connect } from "react-redux";
 
 const ProductsContainer = styled.div`
   display: flex;
@@ -15,6 +15,7 @@ const ProductsContainer = styled.div`
   justify-content: space-evenly;
   position: relative;
 `;
+
 
 const ExploreShopLink = styled(Link)`
   display: block;
@@ -36,38 +37,30 @@ const ExploreShopLink = styled(Link)`
   }
 `;
 
-const Products = ({ title, hasTopBottomBorders }) => {
-  const [featuredProducts, setFeaturedProducts] = useState([]);
-
-  // TODO: figure out how to avoid re-fetching on route changes
-  if (featuredProducts.length === 0) {
-    // make query with items sorted by MANUAL order
-    client.graphQLClient
-      .send(queryFeaturedProductsCollection, { sortKey: "MANUAL" })
-      .then(({ model, data }) => {
-        // store products in local state
-        setFeaturedProducts(data.collectionByHandle.products.edges);
-      })
-      .catch( error => console.log("Error fetching featured-products collection: ", error));
-  }
+const Products = ({products, title, hasTopBottomBorders}) => {
 
   return (
     <ComponentWrapper hasTopBottomBorders={hasTopBottomBorders}>
       <StyledH2> {title} </StyledH2>
       <ProductsContainer>
-        {featuredProducts
-        .map(product => (
-          <Product key={product.id} product={product} />
-        ))}
+        {products
+          .filter(product => product.collections.edges[0].node.handle === "featured-products")
+          .map(product => (
+            <Product key={product.id} product={product} />
+          ))}
       </ProductsContainer>
       <ExploreShopLink to="/shop">Explore the Shop</ExploreShopLink>
     </ComponentWrapper>
   );
 };
 
+const mapStateToProps = ( {products} ) => ({
+  products
+});
+
 Products.propTypes = {
   products: PropTypes.array,
   title: PropTypes.string
 }
 
-export default Products;
+export default connect(mapStateToProps)(Products);

--- a/src/pages/Checkout/Checkout.js
+++ b/src/pages/Checkout/Checkout.js
@@ -11,7 +11,7 @@ import * as CartActionCreators from '../../state/actions/cart';
 import LineItems from './LineItems';
 import LineItemHeaders from './LineItemHeaders';
 import SubtotalSection from './SubtotalSection';
-import FeaturedProducts from '../../SharedComponents/FeaturedProducts';
+import Products from '../../SharedComponents/Products';
 
 const CheckoutContainer = styled.div`
   display: block;
@@ -160,12 +160,12 @@ export class Checkout extends PureComponent {
             calculatedCartSubtotal={calculatedCartSubtotal}
             createCheckoutButton={this.createCheckoutButton}
           />
-          <FeaturedProducts title={"Continue Shopping"} />
+          <Products title={"Continue Shopping"} />
         </CheckoutContainer>
       ) : (
         <CheckoutContainer>
           <StyledH2>Your Shopping Cart is empty.</StyledH2>
-          <FeaturedProducts title={"Explore the Shop"} />
+          <Products title={"Explore the Shop"} />
         </CheckoutContainer>
       )
     )

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -1,6 +1,6 @@
 import React from "react"
 import WelcomeSection from "./WelcomeSection"
-import FeaturedProducts from "../../SharedComponents/FeaturedProducts"
+import Products from "../../SharedComponents/Products"
 import PageWrapper from "../../SharedComponents/PageWrapper"
 
 import About from "./About"
@@ -12,7 +12,7 @@ import RecipeSection from './RecipeSection'
 const Home = () =>
     <PageWrapper>
       <WelcomeSection />
-      <FeaturedProducts title={"Featured Products"} hasTopBottomBorders={true}/>
+      <Products title={"Featured Products"} hasTopBottomBorders={true}/>
       <About />
       <PhotoSection />
       <Process />

--- a/src/pages/Product/Product.js
+++ b/src/pages/Product/Product.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
-import FeaturedProducts from '../../SharedComponents/FeaturedProducts';
+import Products from '../../SharedComponents/Products';
 import Reviews from './Reviews';
 import ProductDetails from './ProductDetails';
 import PageWrapper from "../../SharedComponents/PageWrapper";
@@ -39,7 +39,7 @@ const Product = ({
           doesItemExist={handleIfItemExists}
         />
         <Reviews />
-        <FeaturedProducts title={"More Products"} />
+        <Products title={"More Products"} />
       </div>
     ) : null
   }

--- a/src/pages/Product/ProductDescription.js
+++ b/src/pages/Product/ProductDescription.js
@@ -90,6 +90,7 @@ const ProductDetails = ({
   
   // handle null values for quantityButtonAmount
   const quantity = quantityButtonAmount === "" ? 0 : quantityButtonAmount;
+  console.log("what is metafields?: ", metafields)
   // begin component's return
   return (
     <ProductDetailsWrapper>

--- a/src/pages/Recipe/Recipe.js
+++ b/src/pages/Recipe/Recipe.js
@@ -5,7 +5,7 @@ import styled from "styled-components";
 
 import { device } from "../../utils/devices";
 
-import FeaturedProducts from '../../SharedComponents/FeaturedProducts';
+import Products from '../../SharedComponents/Products';
 import PageWrapper from '../../SharedComponents/PageWrapper';
 import StyledH1 from '../../SharedComponents/StyledH1';
 
@@ -88,7 +88,7 @@ const Recipe = ({
   return (
     <PageWrapper>
       {createRecipe()}
-      <FeaturedProducts title={"Explore the Shop"} />
+      <Products title={"Explore the Shop"} />
     </PageWrapper>
   );
 };

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -14,6 +14,7 @@ const ProductsContainer = styled.div`
   margin: 70px 0;
 `;
 
+
 const Shop = ({products}) => {
 
   return (

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -1,62 +1,7 @@
 import { fetchPending, fetchSuccess, fetchError } from './actions/cart';
 import { client } from "../plugins/shopify.js";
 
-// FETCH "featured-products" COLLECTION
-
-  // create variable to use sortKey
-  const sortKey = client.graphQLClient.variable(
-    "sortKey",
-    "ProductCollectionSortKeys"
-  );
-  
-  // query to get collection with handle === "featured-products"
-  export const queryFeaturedProductsCollection = client.graphQLClient.query([sortKey], root => {
-    root.add(
-      "collectionByHandle",
-      { args: { handle: "featured-products" } },
-      collection => {
-        collection.add("id");
-        collection.addConnection(
-          "products",
-          { args: { sortKey: sortKey, first: 5} },
-          product => {
-            product.add("title");
-            product.add("descriptionHtml");
-            product.add("handle");
-            product.add("availableForSale");
-            product.addConnection(
-              "collections",
-              { args: { first: 2 } },
-              collection => {
-                collection.add("handle");
-              }
-            );
-            product.addConnection(
-              "metafields",
-              { args: { first: 2 } },
-              metafield => {
-                metafield.add("key");
-                metafield.add("value");
-              }
-            );
-            product.addConnection("images", { args: { first: 10 } }, image => {
-              image.add("id");
-              image.add("src");
-              image.add("altText");
-            });
-            product.addConnection(
-              "variants",
-              { args: { first: 1 } },
-              variant => {
-                variant.add("id");
-                variant.add("price");
-              }
-            );
-          }
-        );
-      }
-    );
-  });
+// Here's the actions for fetching shopify data
 
 // create query for shopify articles, used in getArticles
 const articlesQuery = client.graphQLClient.query(root => {


### PR DESCRIPTION
Reverts dbridenbeck/whidbey-herbal#83

Reverting because this branch, and the branch "refactor-shop-page-shopify-fetching" ultimately lead to the product page being broken if navigated to directly.

In lieu of pulling shopify data in the components that request them (products.js, shop.js) I am going to continue fetching for shopify data within Layout for now.

When I hope to refactor this code to request shopify data within the components that request them, take a look at the branch "refactor-shop-page-shopify-fetching" for where I left off before realizing that this broke product pages when navigated to directly.