### PR TITLE
Create out of stock ui

### DIFF
--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -53,6 +53,7 @@ const ProductContainer = styled.div`
         @media ${device.laptop} {
           display: block;
         }
+      }
       `
         : null}
   @media ${device.tablet} {

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -9,6 +9,7 @@ import StyledH5 from "./StyledH5";
 
 const ProductContainer = styled.div`
   display: block;
+  position: relative;
   width: 35%;
   margin-bottom: 40px;
   :hover h5 {
@@ -22,22 +23,39 @@ const ProductContainer = styled.div`
     text-align: center;
     color: black;
   }
+  .soldOutWarning {
+    position: absolute;
+    width: 100%;
+    height: 80%;
+    z-index: 99;
+    span {
+      display: block;
+      width: 75%;
+      margin: 50% auto 0 auto;
+      padding: 10px;
+      color: #525252;
+      font-weight: bold;
+      text-align: center;
+      background: rgba(230, 197, 100, 0.5);
+      border: 2px solid #525252;
+      border-radius: 10px;
+    }
+  }
   /* 
     The below :last-child rule allows 5 featured products to be shown on laptop
     on Mobile/Tablet, the last product in the Featured-Products collection will be hidden
     If you are on the /shop route, ignore this rule and show all products in shop
   */
-  ${props => props.pathname !== "/shop" ? 
-    `
-    :last-child {
-      display: none;
-      @media ${device.laptop} {
-        display: block;
-      }
-    `
-    : null
-  }
-  }
+    ${props =>
+      props.pathname !== "/shop"
+        ? `
+      :last-child {
+        display: none;
+        @media ${device.laptop} {
+          display: block;
+        }
+      `
+        : null}
   @media ${device.tablet} {
     width: 25%;
     margin-bottom: 20px;
@@ -52,15 +70,17 @@ const ProductLink = styled(Link)`
 `;
 
 const ImageContainer = styled.div`
-    display: block;
-    max-width: 100%;
-    margin-bottom: 20px;
+  position: relative;
+  display: block;
+  max-width: 100%;
+  margin-bottom: 20px;
 `;
 
 const Image = styled.img`
   display: block;
   max-width: 100%;
   max-height: 100%;
+${props => !props.isAvailable ? "opacity: .5" : "opacity: 1"};
 `
 
 const createProduct = (product, clearHeroImg, updateQuantityButton) => {
@@ -70,17 +90,26 @@ const createProduct = (product, clearHeroImg, updateQuantityButton) => {
   }
 
   return (
-    <ProductLink to={`/product/${product.handle}`} onClick={clearHeroImgAndQuantityButton}>
+    <ProductLink
+      to={`/product/${product.handle}`}
+      onClick={clearHeroImgAndQuantityButton}
+      isAvailable={product.availableForSale}
+    >
       <ImageContainer>
+        {!product.availableForSale ? (
+          <div className="soldOutWarning">
+            {" "}
+            <span>SOLD OUT</span>{" "}
+          </div>
+        ) : null}
         <Image
           src={`${product.images.edges[0].node.src}`}
           alt={`${product.description}`}
+          isAvailable={product.availableForSale}
         />
       </ImageContainer>
       <StyledH5 centered={true}> {product.title.toUpperCase()} </StyledH5>
-      <p className="info">
-        ${product.variants.edges[0].node.price}
-      </p>
+      <p className="info">${product.variants.edges[0].node.price}</p>
     </ProductLink>
   );
 };

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -34,11 +34,10 @@ const ProductContainer = styled.div`
       margin: 50% auto 0 auto;
       padding: 10px;
       color: #525252;
-      font-weight: bold;
+      font-size: 1.25em;
       text-align: center;
       background: rgba(230, 197, 100, 0.5);
-      border: 2px solid #525252;
-      border-radius: 10px;
+
     }
   }
   /* 

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -30,14 +30,14 @@ const ProductContainer = styled.div`
     z-index: 99;
     span {
       display: block;
-      width: 75%;
+      width: 100%;
       margin: 50% auto 0 auto;
       padding: 10px;
       color: #525252;
       font-size: 1.25em;
+      font-weight: 300;
       text-align: center;
       background: rgba(230, 197, 100, 0.5);
-
     }
   }
   /* 

--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -41,9 +41,9 @@ const ProductContainer = styled.div`
     }
   }
   /* 
-    The below :last-child rule allows 5 featured products to be shown on laptop
-    on Mobile/Tablet, the last product in the Featured-Products collection will be hidden
-    If you are on the /shop route, ignore this rule and show all products in shop
+    :last-child allows 5 featured products to be shown on laptop, but on Mobile/Tablet
+    the last product in the Featured-Products collection will be hidden. 
+    If you are on the /shop route, ignore this rule altogether and show all products in shop.
   */
     ${props =>
       props.pathname !== "/shop"

--- a/src/pages/Product/ProductDescription.js
+++ b/src/pages/Product/ProductDescription.js
@@ -143,26 +143,26 @@ const ProductDetails = ({
   updateQuantityButton
 }) => {
 
-  console.log("what is selectedProduct?: ", selectedProduct);
-
   // begin component's return
   return (
     <ProductDetailsWrapper>
       <StyledH1 colorIsGrey={false} centered={false}>
         {title}
       </StyledH1>
-      {/* TODO replace AboutText's content with metafield via shopify once I have it whitelisted via graphql admin api */}
+      {/* below HTML is for "about" section */}
       <ShopifyHTML
         dangerouslySetInnerHTML={{
           __html: metafields.edges[0].node.value
         }}
       />
+      {/* CTA block is conditionally rendered depending on availableForSale */}
       {createCTABlock(
         selectedProduct,
         doesItemExist,
         updateQuantityButton,
         quantityButtonAmount
       )}
+      {/* below HTML is for Characteristics, Uses, and Common-Sense Caution */}
       <ShopifyHTML
         dangerouslySetInnerHTML={{
           __html: descriptionHtml

--- a/src/pages/Product/ProductDescription.js
+++ b/src/pages/Product/ProductDescription.js
@@ -43,6 +43,7 @@ const ProductDetailsWrapper = styled.div`
 `;
 
 const CTABlock = styled.div`
+  position: relative;
   display: flex;
   flex-direction: row;
   justify-content: space-between;
@@ -68,41 +69,38 @@ const CTABlock = styled.div`
       width: 30%;
     }
   }
+  .soldOutWarning {
+    position: absolute;
+    width: 100%;
+    span {
+      display: block;
+      width: 100%;
+      margin: 0 auto;
+      padding: 0px;
+      color: #525252;
+      font-size: 1.5em;
+      font-weight: 300;
+      text-align: right;
+    }
+  }
 `;
 
 const ShopifyHTML = styled.div`
   margin-top: 30px;
 `;
 
-// begin component
-const ProductDetails = ({
-  selectedProduct,
-  selectedProduct: {
-    title, 
+const createCTABlock = (selectedProduct, doesItemExist, updateQuantityButton, quantityButtonAmount) => {
+  const { 
     variants, 
-    descriptionHtml,
-    metafields
-  },
-  doesItemExist,
-  quantityButtonAmount,
-  updateQuantityButton
-}) => {
-  
+    metafields,
+    availableForSale
+  } = selectedProduct;
+
   // handle null values for quantityButtonAmount
   const quantity = quantityButtonAmount === "" ? 0 : quantityButtonAmount;
-  console.log("what is metafields?: ", metafields)
-  // begin component's return
+
   return (
-    <ProductDetailsWrapper>
-      <StyledH1 colorIsGrey={false} centered={false}>
-        {title}
-      </StyledH1>
-      {/* TODO replace AboutText's content with metafield via shopify once I have it whitelisted via graphql admin api */}
-      <ShopifyHTML
-        dangerouslySetInnerHTML={{
-          __html: metafields.edges[0].node.value
-        }}
-      />
+    availableForSale ? (
       <CTABlock>
         <span className="price">${variants.edges[0].node.price}</span>
         <QuantityButton
@@ -120,6 +118,51 @@ const ProductDetails = ({
           maxQuantity={parseInt(metafields.edges[1].node.value)}
         />
       </CTABlock>
+    ) : (
+      <CTABlock>
+        <span className="price">${variants.edges[0].node.price}</span>
+        <div className="soldOutWarning">
+          {" "}
+          <span>SOLD OUT</span>{" "}
+        </div>
+      </CTABlock>
+    )
+  )
+}
+
+// begin component
+const ProductDetails = ({
+  selectedProduct,
+  selectedProduct: {
+    title, 
+    descriptionHtml,
+    metafields
+  },
+  doesItemExist,
+  quantityButtonAmount,
+  updateQuantityButton
+}) => {
+
+  console.log("what is selectedProduct?: ", selectedProduct);
+
+  // begin component's return
+  return (
+    <ProductDetailsWrapper>
+      <StyledH1 colorIsGrey={false} centered={false}>
+        {title}
+      </StyledH1>
+      {/* TODO replace AboutText's content with metafield via shopify once I have it whitelisted via graphql admin api */}
+      <ShopifyHTML
+        dangerouslySetInnerHTML={{
+          __html: metafields.edges[0].node.value
+        }}
+      />
+      {createCTABlock(
+        selectedProduct,
+        doesItemExist,
+        updateQuantityButton,
+        quantityButtonAmount
+      )}
       <ShopifyHTML
         dangerouslySetInnerHTML={{
           __html: descriptionHtml

--- a/src/pages/Product/ProductDetails.js
+++ b/src/pages/Product/ProductDetails.js
@@ -26,7 +26,10 @@ const ProductDetails = ({
 }) => {
   return (
     <ProductInfoWrapper>
-      <ProductImages images={selectedProduct.images}/>
+      <ProductImages 
+        images={selectedProduct.images}
+        selectedProduct={selectedProduct}
+      />
       <ProductDescription 
         selectedProduct={selectedProduct} 
         doesItemExist={doesItemExist}

--- a/src/pages/Product/ProductImages.js
+++ b/src/pages/Product/ProductImages.js
@@ -9,8 +9,25 @@ import styled from "styled-components";
 
 // Begin Styled Components
 const ProductImagesWrapper = styled.div`
+  position: relative;
   width: 100%;
   margin: 0 auto;
+  .soldOutWarning {
+    position: absolute;
+    width: 100%;
+    height: 40%;
+    span {
+      display: block;
+      width: 100%;
+      margin: 50% auto 0 auto;
+      padding: 10px;
+      color: #525252;
+      font-size: 2em;
+      font-weight: 300;
+      text-align: center;
+      background: rgba(230, 197, 100, 0.5);
+    }
+  }
   @media ${device.tablet} {
     width: 45%;
   }
@@ -58,6 +75,7 @@ const ProductImages = ({
   heroImgSrc,
   heroImgId,
   handleHeroImg,
+  selectedProduct: {availableForSale}
 }) => {
 
   // when clicked, AltImage updates state and sets heroImg's src to AltImage
@@ -85,15 +103,17 @@ const ProductImages = ({
   // begin component's return
   return (
     <ProductImagesWrapper>
+      {!availableForSale ? (
+        <div className="soldOutWarning">
+          {" "}
+          <span>SOLD OUT</span>{" "}
+        </div>
+      ) : null}
       <HeroImage
-        src={
-          heroImgSrc ? heroImgSrc : images.edges[0].node.src
-        }
+        src={heroImgSrc ? heroImgSrc : images.edges[0].node.src}
         alt="Product Photo"
       />
-      <AltImages>
-        {images.edges.map(image => createAltImage(image))}
-      </AltImages>
+      <AltImages>{images.edges.map(image => createAltImage(image))}</AltImages>
     </ProductImagesWrapper>
   );
 };

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -24,7 +24,6 @@ const Shop = ({products}) => {
       </StyledH1>
       <ProductsContainer>
         {products
-          .filter(product => product.availableForSale)
           .map(product => (
             <Product key={product.id} product={product} />
           ))}


### PR DESCRIPTION
# Purpose
- To show when products are out of stock and prevent users from adding these items to cart

# Validating
- Make sure that FeaturedProducts continue to appear as usual in all contexts
- When item's quantity hits 0 three things should happen: **1)** SOLD OUT banner should appear on SharedProduct/Product.js, **2)** SOLD OUT should appear on HeroImg on product page, **3)** SOLD OUT should appear where QuantityButton and BuyButton usually appear within the CTABlock

# Background Context
- It's not uncommon for items to run out of stock. Instead of hiding them from the store, we would rather let users still explore these items, but prevent them from adding them to cart, and alert them that these items are out of stock

# Follow-On Questions
- Still need to implement method to check shopify and update state if product info changes, otherwise items could run out of stock, but still be stored in localstorage as being available for sale
- Additionally, in v2, the underlying logic for this is likely to change as I integrate a backend that uses the Admin API and can see inventory directly.

# Extra Release Steps
- none