### PR TITLE
Fix page transitions

### DIFF
--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -11,7 +11,6 @@ import {
   updateFeaturedProductsAction,
   updateShopifyArticlesAction
 } from "../state/fetchShopifyData";
-import Footer from '../SharedComponents/Footer';
 import styled from "styled-components";
 import Header from "./Header"
 
@@ -76,7 +75,6 @@ const Layout = ({
         <Header />
         <div id="home">{children}</div>
       </MasterWrapper>
-      {/* <Footer /> */}
     </>
   );
 };

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -21,7 +21,6 @@ const MasterWrapper = styled.div`
   height: ${props => props.height};
   max-width: 1200px;
   margin: 60px auto 120px auto;
-  padding: 0px 20px 0 20px;
 `;
 
 const Layout = ({

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -76,7 +76,7 @@ const Layout = ({
         <Header />
         <div id="home">{children}</div>
       </MasterWrapper>
-      <Footer />
+      {/* <Footer /> */}
     </>
   );
 };

--- a/src/SharedComponents/ComponentWrapper.js
+++ b/src/SharedComponents/ComponentWrapper.js
@@ -11,7 +11,7 @@ const StyledWrapper = styled.div`
   margin: ${props =>
     props.id === "process" ? "0px auto -3% auto" : "0px auto 0px auto"};
   padding: ${props =>
-    props.id === "process" ? "200px 0 12% 0" : "200px 0 0px 0"};
+    props.id === "process" ? "200px 0 12% 0" : "200px 0px 0px 0px"};
   border-top: ${props => props.hasTopBottomBorders ? "1px solid black" : "none"};
   border-bottom: ${props => props.hasTopBottomBorders ? "1px solid black" : "none"};
   /* Create full width color bars */

--- a/src/SharedComponents/ComponentWrapper.js
+++ b/src/SharedComponents/ComponentWrapper.js
@@ -14,13 +14,14 @@ const StyledWrapper = styled.div`
     props.id === "process" ? "200px 0 12% 0" : "200px 0 0px 0"};
   border-top: ${props => props.hasTopBottomBorders ? "1px solid black" : "none"};
   border-bottom: ${props => props.hasTopBottomBorders ? "1px solid black" : "none"};
+  /* Create full width color bars */
   ${({ backgroundColor }) =>
     backgroundColor &&
     `
     position: relative;
-    width: 100vw;
-    left: 50%;
-    right: 50%;
+    width: 110vw;
+    left: 45%;
+    right: 45%;
     margin-left: -50vw;
     margin-right: -50vw;
     background-color: ${backgroundColor};

--- a/src/SharedComponents/FeaturedProducts.js
+++ b/src/SharedComponents/FeaturedProducts.js
@@ -16,7 +16,6 @@ const ProductsContainer = styled.div`
   position: relative;
 `;
 
-
 const ExploreShopLink = styled(Link)`
   display: block;
   width: 40%;
@@ -43,10 +42,11 @@ const Products = ({featuredProducts, title, hasTopBottomBorders}) => {
     <ComponentWrapper hasTopBottomBorders={hasTopBottomBorders}>
       <StyledH2> {title} </StyledH2>
       <ProductsContainer>
-        {featuredProducts
-          .map(product => (
-            <Product key={product.id} product={product.node} />
-          ))}
+        {featuredProducts ? 
+          featuredProducts
+            .map(product => (
+              <Product key={product.id} product={product.node} />
+            )) : null}
       </ProductsContainer>
       <ExploreShopLink to="/shop">Explore the Shop</ExploreShopLink>
     </ComponentWrapper>

--- a/src/SharedComponents/Footer.js
+++ b/src/SharedComponents/Footer.js
@@ -10,7 +10,7 @@ import ContactAndSocials from './ContactAndSocials';
     position: relative;
     height: 630px;
     width: 120vw;
-    margin: 0px auto 0 -22%;
+    margin: 140px auto 0 -22%;
     padding: 10% 12% 0 22%;
     background-color: rgba(230, 197, 100, 1);
     ::before {

--- a/src/SharedComponents/Footer.js
+++ b/src/SharedComponents/Footer.js
@@ -9,6 +9,7 @@ import ContactAndSocials from './ContactAndSocials';
     display: block;
     position: relative;
     height: 630px;
+    /* oversize width, negative left margin, and positive right margin create full-bar effect */
     width: 120vw;
     margin: 140px auto 0 -22%;
     padding: 10% 12% 0 22%;
@@ -29,6 +30,14 @@ import ContactAndSocials from './ContactAndSocials';
       display: flex;
       flex-direction: row;
       justify-content: center;
+    }
+    /* adjust full bar effect for large screens */
+    @media ${device.largeScreen} {
+      width: 100vw;
+      margin-top: 140px;
+      margin-left: calc(((-100vw / 2) + (1200px / 2)) - 20px);
+      margin-right: calc(-100vw / 2 + 1200px / 2);
+
     }
   `;
 

--- a/src/SharedComponents/Footer.js
+++ b/src/SharedComponents/Footer.js
@@ -33,7 +33,6 @@ import ContactAndSocials from './ContactAndSocials';
   `;
 
 const Footer = () => {
-
   return (
     <FooterContainer>
       <NewsletterSignup />

--- a/src/SharedComponents/Footer.js
+++ b/src/SharedComponents/Footer.js
@@ -9,9 +9,9 @@ import ContactAndSocials from './ContactAndSocials';
     display: block;
     position: relative;
     height: 630px;
-    width: 100vw;
-    margin: 0px auto 0px auto;
-    padding: 150px 20px 0 20px;
+    width: 120vw;
+    margin: 0px auto 0 -22%;
+    padding: 10% 12% 0 22%;
     background-color: rgba(230, 197, 100, 1);
     ::before {
       content: "";

--- a/src/SharedComponents/Footer.js
+++ b/src/SharedComponents/Footer.js
@@ -35,6 +35,8 @@ import ContactAndSocials from './ContactAndSocials';
     @media ${device.largeScreen} {
       width: 100vw;
       margin-top: 140px;
+      /* maring-left and margin-right used to create full bar given Layout's MasterWrapper 
+      has a known width of 1200px on large screens and -20px is used to offset pagewrapper's 20px left padding */
       margin-left: calc(((-100vw / 2) + (1200px / 2)) - 20px);
       margin-right: calc(-100vw / 2 + 1200px / 2);
 

--- a/src/SharedComponents/PageWrapper.js
+++ b/src/SharedComponents/PageWrapper.js
@@ -6,7 +6,7 @@ const StyledWrapper = styled.div`
   position: absolute;
   width: 100%;
   margin: 0px auto 0px auto;
-  padding: 50px 20px 0px 20px;
+  padding: 0px 20px 0px 20px;
 `;
 
 const PageWrapper = ({maxWidth, children, id, positionRelative}) => {

--- a/src/SharedComponents/PageWrapper.js
+++ b/src/SharedComponents/PageWrapper.js
@@ -3,9 +3,8 @@ import styled from "styled-components";
 
 const StyledWrapper = styled.div`
   display: block;
-  position: relative;
+  position: absolute;
   width: 100%;
-  height: 100%;
   margin: 0px auto 0px auto;
   padding: 50px 20px 0px 20px;
 `;

--- a/src/SharedComponents/PageWrapper.js
+++ b/src/SharedComponents/PageWrapper.js
@@ -16,6 +16,7 @@ const PageWrapper = ({maxWidth, children, id, positionRelative}) => {
       maxWidth={maxWidth}
       id={id}
       positionRelative={positionRelative}
+      className="page-wrapper"
     >{children}</StyledWrapper>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -14,6 +14,11 @@ html {
   overflow-x: hidden;
 }
 
+body {
+  padding: 0;
+  margin: 0;
+}
+
 @media (min-width: 768px) {
   body {font-size: 1.125em;}
 }

--- a/src/index.css
+++ b/src/index.css
@@ -5,7 +5,7 @@
 h1 {font-family: 'Domine', serif;}
 h2, h3 {font-family: 'Open Sans', sans-serif;}
 
-html, body {
+html {
   margin: 0;
   padding: 0;
   border: 0;

--- a/src/pages/Checkout/Checkout.js
+++ b/src/pages/Checkout/Checkout.js
@@ -12,6 +12,7 @@ import LineItems from './LineItems';
 import LineItemHeaders from './LineItemHeaders';
 import SubtotalSection from './SubtotalSection';
 import FeaturedProducts from '../../SharedComponents/FeaturedProducts';
+import Footer from "../../SharedComponents/Footer";
 
 const CheckoutContainer = styled.div`
   display: block;
@@ -178,6 +179,7 @@ export class Checkout extends PureComponent {
           Checkout
         </StyledH1>
         {this.createCheckoutContainer()}
+        <Footer />
       </PageWrapper>
     );
   }

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -8,6 +8,8 @@ import PhotoSection from './PhotoSection'
 import Process from "./Process"
 import StoreLocator from "./StoreLocator"
 import RecipeSection from './RecipeSection'
+import Footer from "../../SharedComponents/Footer";
+
 
 const Home = () =>
     <PageWrapper>
@@ -18,6 +20,7 @@ const Home = () =>
       <Process />
       <StoreLocator />
       <RecipeSection />
+      <Footer />
     </PageWrapper>
 
 export default Home;

--- a/src/pages/Home/PhotoBumpOut.js
+++ b/src/pages/Home/PhotoBumpOut.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import styled from "styled-components";
+import { device } from "../../utils/devices";
 import bottlesAndHoney from "./images/bottles-and-honey.jpg";
 
 const BumpOutContainer = styled.div`
@@ -7,7 +8,10 @@ const BumpOutContainer = styled.div`
   width: 51%;
   /* negative right margin to push image to right of screen on laptop/tablet/mobile */
   /* negative top margin to stagger it with the last processblock */
-  margin: -22% -12.5% 0 0;
+  margin: 10% -12.5% 0 0;
+  @media ${device.tablet} {
+    margin: -22% -8% 0 0;
+  }
   align-self: flex-end;
   img {
     position: relative;

--- a/src/pages/Product/Product.js
+++ b/src/pages/Product/Product.js
@@ -5,6 +5,7 @@ import FeaturedProducts from '../../SharedComponents/FeaturedProducts';
 import Reviews from './Reviews';
 import ProductDetails from './ProductDetails';
 import PageWrapper from "../../SharedComponents/PageWrapper";
+import Footer from "../../SharedComponents/Footer";
 
 // begin component
 const Product = ({
@@ -48,6 +49,7 @@ const Product = ({
   return (
     <PageWrapper>
       {createProductDetails()}
+      <Footer />
     </PageWrapper>
   );
 };

--- a/src/pages/Recipe/Recipe.js
+++ b/src/pages/Recipe/Recipe.js
@@ -6,6 +6,7 @@ import { device } from "../../utils/devices";
 import FeaturedProducts from '../../SharedComponents/FeaturedProducts';
 import PageWrapper from '../../SharedComponents/PageWrapper';
 import StyledH1 from '../../SharedComponents/StyledH1';
+import Footer from "../../SharedComponents/Footer";
 
 // Begin Styled Components
 const RecipeContainer = styled.div`
@@ -87,6 +88,7 @@ const Recipe = ({
     <PageWrapper>
       {createRecipe()}
       <FeaturedProducts title={"Explore the Shop"} />
+      <Footer />
     </PageWrapper>
   );
 };

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -4,6 +4,7 @@ import styled from "styled-components";
 import PageWrapper from "../../SharedComponents/PageWrapper";
 import Product from "../../SharedComponents/Product";
 import StyledH1 from "../../SharedComponents/StyledH1";
+import Footer from "../../SharedComponents/Footer";
 
 const ProductsContainer = styled.div`
   display: flex;
@@ -28,6 +29,7 @@ const Shop = ({products}) => {
             <Product key={product.id} product={product} />
           ))}
       </ProductsContainer>
+      <Footer />
     </PageWrapper>
   );
 };


### PR DESCRIPTION
# Purpose
- Page transitions were broken as a result of Page Wrapper having relative positioning
- Desired transition: (instead of transitioning from 1 to 0 opacity, with the new page "behind" the old page with opacity of 1)
- Actual behavior: Since PageWrapper had relative positioning, the new page would appear below the old page, and then abruptly appear at the top of the page
- Additionally, when clicking the navbar links for the home page (logo image, process, about, find a store, recipes) the scrolling behavior wasn't ending at the section that was expected, rather it stopped in the middle of sections, at the wrong section.
- Getting page transitions to work had severe impact on how the footer behaved, which required moving the footer out of Layout.js (since the page wrapper is absolutely positioned) and into each page itself
- Additionally, this required the Footer's css to be adjusted using negative margins on laptop and smaller devices, and then using margin-left and margin-right calc since the MasterWrapper then had a known width of 1200px 

# Validating
- Page transitions should work in every permutation possible, with the old page fading to 0 opacity, with the new page behind it
- When clicking links to the home page, it should scroll to the intended section
- Footer's pattern background should be full width in all contexts with no text spilling outside the bounds of the screen

# Background Context
- Somehow in a previous branch Page Wapper's position was set to relative, when it needs to be absolute for the page transitions to work. Restoring this behavior took a lot of work!

# Follow-On Questions
- Negative margins for the Footer still seems wrong. I'd like to revisit this to help ensure that it's content is always centered in all contexts - in some smaller screens it feels too far left aligned

# Extra Release Steps