### PR TITLE
Add google analytics

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12964,6 +12964,11 @@
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.4.tgz",
       "integrity": "sha512-ueZzLmHltszTshDMwyfELDq8zOA803wQ1ZuzCccXa1m57k1PxSHfflPD5W9YIiTXLs0JTLzoj6o1LuM5N6zzNA=="
     },
+    "react-ga": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-ga/-/react-ga-2.7.0.tgz",
+      "integrity": "sha512-AjC7UOZMvygrWTc2hKxTDvlMXEtbmA0IgJjmkhgmQQ3RkXrWR11xEagLGFGaNyaPnmg24oaIiaNPnEoftUhfXA=="
+    },
     "react-google-maps": {
       "version": "9.4.5",
       "resolved": "https://registry.npmjs.org/react-google-maps/-/react-google-maps-9.4.5.tgz",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "node-sass": "^4.13.0",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",
+    "react-ga": "^2.7.0",
     "react-google-maps": "^9.4.5",
     "react-redux": "^7.1.3",
     "react-router-dom": "^5.1.2",

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -1,4 +1,4 @@
-import React, { useEffect } from "react";
+import React from "react";
 import { connect } from "react-redux";
 import PropTypes from "prop-types";
 import { client } from "../plugins/shopify.js";

--- a/src/pages/Home/About.js
+++ b/src/pages/Home/About.js
@@ -48,7 +48,7 @@ const About = () => {
         <source srcSet={`${farmersWebp}`} type='image/webp' />
         <source srcSet={`${farmers}`} type='image/jpeg' />
         <img src={`${farmers}`}
-        alt="Watercolor image of Sam and Caitlin, the farmers of Whidbey Herbal"
+        alt="Watercolor of Sam and Caitlin, the farmers of Whidbey Herbal"
         />
       </FarmerIllustration>
         

--- a/src/root.js
+++ b/src/root.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import  { BrowserRouter as Router } from 'react-router-dom';
+import { createBrowserHistory } from 'history';
+import ReactGA from 'react-ga';
+import  { Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
 import { createStore, applyMiddleware, compose } from 'redux';
 import ScrollToTop from './utils/ScrollToTop';
@@ -9,6 +11,14 @@ import App from './App';
 import { saveToLocalStorage, getFromLocalStorage } from "../src/state/localStorage";
 import thunk from "redux-thunk";
 import "./index.css";
+
+// google analytics config
+const history = createBrowserHistory();
+const trackingId = "UA-151317774-1";
+ReactGA.initialize(trackingId);
+history.listen((location, action) => {
+  ReactGA.pageview(location.pathname + location.search);
+});
 
 const Root = () => {
 
@@ -33,7 +43,7 @@ const Root = () => {
     
   return (
     <Provider store={store}>
-      <Router basename={process.env.PUBLIC_URL}>
+      <Router basename={process.env.PUBLIC_URL} history={history}>
         <ScrollToTop />
         <App />
       </Router>


### PR DESCRIPTION
# Purpose
- Add Google Analytics to the site

# Validating
- Will need to check WH's google analytics once we switch the site over, to make sure it's tracking correctly

# Background Context
- Current Shopify site uses google analytics, so this version should too!

# Follow-On Questions
- Currently only tracking the following behavior: 
```
ReactGA.pageview(location.pathname + location.search);
```
In the future we probably want to add more tracking to this.

# Extra Release Steps
- none