### PR TITLE
Product title adjustments

### DIFF
--- a/src/SharedComponents/Product.js
+++ b/src/SharedComponents/Product.js
@@ -57,11 +57,11 @@ const ProductContainer = styled.div`
       `
         : null}
   @media ${device.tablet} {
-    width: 25%;
+    width: 22.5%;
     margin-bottom: 20px;
   }
   @media ${device.laptop} {
-    width: 20%;
+    width: 17.5%;
   }
 `;
 

--- a/src/SharedComponents/StyledH5.js
+++ b/src/SharedComponents/StyledH5.js
@@ -5,17 +5,15 @@ import { device } from "../utils/devices";
 const H5Component = styled.h5`
   margin-bottom: 5px;
   padding: 0;
-  font-size: .925rem;
+  font-size: .825rem;
   font-weight: bold;
   color: #2e2e2e;
   text-align: center;
   @media ${device.tablet} {
-  font-size: 1.125rem;
-    
+    font-size: 1rem;
   }
   @media ${device.laptop} {
-  font-size: 1.313rem;
-
+    font-size: 1.313rem;
   }
 `;
 

--- a/src/pages/Checkout/LineItem.js
+++ b/src/pages/Checkout/LineItem.js
@@ -50,6 +50,7 @@ const ProductTitleLink = styled(Link)`
   color: #e3be42;
   text-decoration: none;
   line-height: 1.125em;
+  padding: 0 5px;
   :hover {
     color: #787878;
   }


### PR DESCRIPTION
# Purpose
- Provide spacing for FeaturedProduct titles (via decreasing ProductContainer's width) and Checkout's lineitem's title (via adding left and right padding of 5px)

# Validating
- FeaturedProduct's titles should not be closely bunched next to each other in laptop+ devices
- Checkout's lineitem's ProductTitleLink should not be nearly touching product's price (Adding Red Cedar to cart is a good test for this)

# Background Context
- These are some post-publish tweaks we decided to make after deploying to whidbeyherbal.com

# Follow-On Questions
- None

# Extra Release Steps
- None