### PR TITLE
Implement wholesale shop

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -20,6 +20,7 @@ const App = () => {
         <Route exact path="/whidbey-herbal" component={Home} />
         <Route path="/checkout" component={Checkout} />
         <Route path="/shop" component={Shop} />
+        <Route path="/wholesale" component={Shop} />
         <Route path="/product/:handle" component={Product} />
         <Redirect from="/product/" to="/shop" />
         <Route path="/recipe/:handle" component={Recipe} />

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -61,7 +61,6 @@ const Layout = ({
 
   // if products haven't been fetched, fetch them
   if (!onlineStore.length) {
-    console.log("fetching stuff");
     // populate state with products and articles from shopify
     fetchOnlineStoreCollection();
     fetchFeaturedProducts();

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -8,10 +8,12 @@ import * as CartActionCreators from "../state/actions/cart";
 import {
   fetchShopifyProductsAction,
   fetchShopifyArticlesAction,
-  fetchFeaturedProductsAction,
+  fetchProductCollectionAction,
+  handleDispatchingFeaturedProducts,
+  queryCollection,
   updateShopifyProductsAction,
   updateFeaturedProductsAction,
-  updateShopifyArticlesAction
+  updateShopifyArticlesAction,
 } from "../state/fetchShopifyData";
 import styled from "styled-components";
 import Header from "./Header";
@@ -108,20 +110,27 @@ const mapStateToProps = ({
   lastShopifyFetchTimestamp
 });
 
-const mapDispatchToProps = dispatch => ({
+const mapDispatchToProps = (dispatch) => ({
   clearCheckoutInState: () =>
     dispatch(CartActionCreators.clearCheckoutInState()),
   fetchShopifyProducts: () => dispatch(fetchShopifyProductsAction()),
   fetchShopifyArticles: () => dispatch(fetchShopifyArticlesAction()),
-  fetchFeaturedProducts: () => dispatch(fetchFeaturedProductsAction()),
+  fetchFeaturedProducts: () =>
+    dispatch(
+      fetchProductCollectionAction(
+        queryCollection,
+        "featured-products",
+        handleDispatchingFeaturedProducts
+      )
+    ),
   updateShopifyFetchTimestamp: () =>
     dispatch(CartActionCreators.updateShopifyFetchTimestamp()),
-  updateShopifyProducts: productsFromRedux =>
+  updateShopifyProducts: (productsFromRedux) =>
     dispatch(updateShopifyProductsAction(productsFromRedux)),
-  updateFeaturedProducts: featuredProductsFromRedux =>
+  updateFeaturedProducts: (featuredProductsFromRedux) =>
     dispatch(updateFeaturedProductsAction(featuredProductsFromRedux)),
-  updateShopifyArticles: articlesFromRedux =>
-    dispatch(updateShopifyArticlesAction(articlesFromRedux))
+  updateShopifyArticles: (articlesFromRedux) =>
+    dispatch(updateShopifyArticlesAction(articlesFromRedux)),
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(React.memo(Layout));

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -62,14 +62,13 @@ const Layout = ({
     clearCheckoutIfCompleted();
   }
 
-  // if products haven't been fetched, fetch them
+  // if products or articles haven't been fetched, fetch them
   if (
       !onlineStore.length || 
       !featuredProducts.length || 
       !wholesaleProducts.length || 
       !articles.length
     ) {
-    // populate state with products and articles from shopify
       fetchOnlineStoreCollection();
       fetchFeaturedProducts();
       fetchWholesaleStoreCollection();

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -82,7 +82,6 @@ const Layout = ({
     Date.now() > lastShopifyFetchTimestamp + 300000 &&
     lastShopifyFetchTimestamp !== 0
   ) {
-      console.log("trying to update!");
       updateOnlineStoreCollection(onlineStore);
       updateFeaturedProducts(featuredProducts);
       updateWholesaleProducts(wholesaleProducts);

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -37,13 +37,15 @@ const Layout = ({
   fetchWholesaleStoreCollection,
   updateOnlineStoreCollection,
   updateFeaturedProducts,
+  updateWholesaleProducts,
   updateShopifyArticles,
   updateShopifyFetchTimestamp,
   lastShopifyFetchTimestamp,
   checkoutId,
   onlineStore,
-  articles,
   featuredProducts,
+  wholesaleProducts,
+  articles,
 }) => {
   const clearCheckoutIfCompleted = () => {
     checkoutId
@@ -78,6 +80,7 @@ const Layout = ({
       console.log("trying to update!");
       updateOnlineStoreCollection(onlineStore);
       updateFeaturedProducts(featuredProducts);
+      updateWholesaleProducts(wholesaleProducts);
       updateShopifyArticles(articles);
       updateShopifyFetchTimestamp();
     }
@@ -101,8 +104,9 @@ Layout.propTypes = {
 
 const mapStateToProps = ({
   onlineStore,
-  articles,
   featuredProducts,
+  wholesaleProducts,
+  articles,
   checkout: { checkoutId },
   lastShopifyFetchTimestamp
 }) => ({
@@ -129,8 +133,14 @@ const mapDispatchToProps = (dispatch) => ({
         handleDispatchingProducts
       )
     ),
-  fetchWholesaleStoreCollection: () => 
-    dispatch(fetchProductCollectionAction("wholesale-products", 4, handleDispatchingProducts)),
+  fetchWholesaleStoreCollection: () =>
+    dispatch(
+      fetchProductCollectionAction(
+        "wholesale-products",
+        4,
+        handleDispatchingProducts
+      )
+    ),
   updateShopifyFetchTimestamp: () =>
     dispatch(CartActionCreators.updateShopifyFetchTimestamp()),
   updateOnlineStoreCollection: (onlineStore) =>
@@ -149,6 +159,15 @@ const mapDispatchToProps = (dispatch) => ({
         5,
         handleUpdatingProducts,
         featuredProductsFromRedux
+      )
+    ),
+  updateWholesaleProducts: (wholesaleProducts) =>
+    dispatch(
+      fetchProductCollectionAction(
+        "wholesale-products",
+        4,
+        handleUpdatingProducts,
+        wholesaleProducts
       )
     ),
   updateShopifyArticles: (articlesFromRedux) =>

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -9,8 +9,8 @@ import {
   fetchShopifyProductsAction,
   fetchShopifyArticlesAction,
   fetchProductCollectionAction,
-  handleDispatchingFeaturedProducts,
-  handleUpdatingFeaturedProducts,
+  handleDispatchingProducts,
+  handleUpdatingProducts,
   updateShopifyProductsAction,
   updateCollectionAction,
   updateShopifyArticlesAction,
@@ -34,7 +34,7 @@ const MasterWrapper = styled.div`
 const Layout = ({
   children,
   clearCheckoutInState,
-  fetchShopifyProducts,
+  fetchOnlineStoreCollection,
   fetchShopifyArticles,
   fetchFeaturedProducts,
   updateShopifyProducts,
@@ -43,13 +43,13 @@ const Layout = ({
   updateShopifyFetchTimestamp,
   lastShopifyFetchTimestamp,
   checkoutId,
-  products,
+  onlineStore,
   articles,
-  featuredProducts
+  featuredProducts,
 }) => {
   const clearCheckoutIfCompleted = () => {
     checkoutId
-      ? client.checkout.fetch(checkoutId).then(checkout => {
+      ? client.checkout.fetch(checkoutId).then((checkout) => {
           if (checkout.completedAt) {
             clearCheckoutInState();
           }
@@ -63,20 +63,25 @@ const Layout = ({
   }
 
   // if products haven't been fetched, fetch them
-  if (!products.length) {
+  if (!onlineStore.length) {
+    console.log("fetching stuff");
     // populate state with products and articles from shopify
-    fetchShopifyProducts();
+    fetchOnlineStoreCollection();
     fetchFeaturedProducts();
     fetchShopifyArticles();
   }
 
   // if 5 minutes passed and it's not the initial page load,
   // check for updates on products, articles, featured products collection, and update timestamp
-  if ((Date.now() > lastShopifyFetchTimestamp + 300000) && (lastShopifyFetchTimestamp !== 0)) {
-    updateShopifyProducts(products);
-    updateShopifyArticles(articles);
-    updateFeaturedProducts(featuredProducts);
-    updateShopifyFetchTimestamp();
+  if (
+    Date.now() > lastShopifyFetchTimestamp + 300000 &&
+    lastShopifyFetchTimestamp !== 0
+  ) {
+    console.log("trying to update!");
+    // updateShopifyProducts(products);
+    // updateShopifyArticles(articles);
+    // updateFeaturedProducts(featuredProducts);
+    // updateShopifyFetchTimestamp();
   }
 
   return (
@@ -97,14 +102,14 @@ Layout.propTypes = {
 };
 
 const mapStateToProps = ({
-  products,
+  onlineStore,
   articles,
   featuredProducts,
   checkout: { checkoutId },
   lastShopifyFetchTimestamp
 }) => ({
   checkoutId,
-  products,
+  onlineStore,
   featuredProducts,
   articles,
   lastShopifyFetchTimestamp
@@ -113,14 +118,14 @@ const mapStateToProps = ({
 const mapDispatchToProps = (dispatch) => ({
   clearCheckoutInState: () =>
     dispatch(CartActionCreators.clearCheckoutInState()),
-  fetchShopifyProducts: () => dispatch(fetchShopifyProductsAction()),
+  fetchOnlineStoreCollection: () => dispatch(fetchProductCollectionAction("online-store", 7, handleDispatchingProducts)),
   fetchShopifyArticles: () => dispatch(fetchShopifyArticlesAction()),
   fetchFeaturedProducts: () =>
     dispatch(
       fetchProductCollectionAction(
         "featured-products",
         5,
-        handleDispatchingFeaturedProducts
+        handleDispatchingProducts
       )
     ),
   updateShopifyFetchTimestamp: () =>
@@ -132,7 +137,7 @@ const mapDispatchToProps = (dispatch) => ({
       fetchProductCollectionAction(
         "featured-products",
         5,
-        handleUpdatingFeaturedProducts,
+        handleUpdatingProducts,
         featuredProductsFromRedux
       )
     ),

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -10,9 +10,9 @@ import {
   fetchShopifyArticlesAction,
   fetchProductCollectionAction,
   handleDispatchingFeaturedProducts,
-  queryCollection,
+  handleUpdatingFeaturedProducts,
   updateShopifyProductsAction,
-  updateFeaturedProductsAction,
+  updateCollectionAction,
   updateShopifyArticlesAction,
 } from "../state/fetchShopifyData";
 import styled from "styled-components";
@@ -118,8 +118,8 @@ const mapDispatchToProps = (dispatch) => ({
   fetchFeaturedProducts: () =>
     dispatch(
       fetchProductCollectionAction(
-        queryCollection,
         "featured-products",
+        5,
         handleDispatchingFeaturedProducts
       )
     ),
@@ -128,7 +128,14 @@ const mapDispatchToProps = (dispatch) => ({
   updateShopifyProducts: (productsFromRedux) =>
     dispatch(updateShopifyProductsAction(productsFromRedux)),
   updateFeaturedProducts: (featuredProductsFromRedux) =>
-    dispatch(updateFeaturedProductsAction(featuredProductsFromRedux)),
+    dispatch(
+      fetchProductCollectionAction(
+        "featured-products",
+        5,
+        handleUpdatingFeaturedProducts,
+        featuredProductsFromRedux
+      )
+    ),
   updateShopifyArticles: (articlesFromRedux) =>
     dispatch(updateShopifyArticlesAction(articlesFromRedux)),
 });

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -34,6 +34,7 @@ const Layout = ({
   fetchOnlineStoreCollection,
   fetchShopifyArticles,
   fetchFeaturedProducts,
+  fetchWholesaleStoreCollection,
   updateOnlineStoreCollection,
   updateFeaturedProducts,
   updateShopifyArticles,
@@ -64,6 +65,7 @@ const Layout = ({
     // populate state with products and articles from shopify
     fetchOnlineStoreCollection();
     fetchFeaturedProducts();
+    fetchWholesaleStoreCollection();
     fetchShopifyArticles();
   }
 
@@ -127,6 +129,8 @@ const mapDispatchToProps = (dispatch) => ({
         handleDispatchingProducts
       )
     ),
+  fetchWholesaleStoreCollection: () => 
+    dispatch(fetchProductCollectionAction("wholesale-products", 4, handleDispatchingProducts)),
   updateShopifyFetchTimestamp: () =>
     dispatch(CartActionCreators.updateShopifyFetchTimestamp()),
   updateOnlineStoreCollection: (onlineStore) =>

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -6,13 +6,10 @@ import { device } from "../utils/devices";
 
 import * as CartActionCreators from "../state/actions/cart";
 import {
-  fetchShopifyProductsAction,
   fetchShopifyArticlesAction,
   fetchProductCollectionAction,
   handleDispatchingProducts,
   handleUpdatingProducts,
-  updateShopifyProductsAction,
-  updateCollectionAction,
   updateShopifyArticlesAction,
 } from "../state/fetchShopifyData";
 import styled from "styled-components";
@@ -37,7 +34,7 @@ const Layout = ({
   fetchOnlineStoreCollection,
   fetchShopifyArticles,
   fetchFeaturedProducts,
-  updateShopifyProducts,
+  updateOnlineStoreCollection,
   updateFeaturedProducts,
   updateShopifyArticles,
   updateShopifyFetchTimestamp,
@@ -77,12 +74,12 @@ const Layout = ({
     Date.now() > lastShopifyFetchTimestamp + 300000 &&
     lastShopifyFetchTimestamp !== 0
   ) {
-    console.log("trying to update!");
-    // updateShopifyProducts(products);
-    // updateShopifyArticles(articles);
-    // updateFeaturedProducts(featuredProducts);
-    // updateShopifyFetchTimestamp();
-  }
+      console.log("trying to update!");
+      updateOnlineStoreCollection(onlineStore);
+      updateFeaturedProducts(featuredProducts);
+      updateShopifyArticles(articles);
+      updateShopifyFetchTimestamp();
+    }
 
   return (
     <>
@@ -118,7 +115,10 @@ const mapStateToProps = ({
 const mapDispatchToProps = (dispatch) => ({
   clearCheckoutInState: () =>
     dispatch(CartActionCreators.clearCheckoutInState()),
-  fetchOnlineStoreCollection: () => dispatch(fetchProductCollectionAction("online-store", 7, handleDispatchingProducts)),
+  fetchOnlineStoreCollection: () =>
+    dispatch(
+      fetchProductCollectionAction("online-store", 7, handleDispatchingProducts)
+    ),
   fetchShopifyArticles: () => dispatch(fetchShopifyArticlesAction()),
   fetchFeaturedProducts: () =>
     dispatch(
@@ -130,8 +130,15 @@ const mapDispatchToProps = (dispatch) => ({
     ),
   updateShopifyFetchTimestamp: () =>
     dispatch(CartActionCreators.updateShopifyFetchTimestamp()),
-  updateShopifyProducts: (productsFromRedux) =>
-    dispatch(updateShopifyProductsAction(productsFromRedux)),
+  updateOnlineStoreCollection: (onlineStore) =>
+    dispatch(
+      fetchProductCollectionAction(
+        "online-store",
+        7,
+        handleUpdatingProducts,
+        onlineStore
+      )
+    ),
   updateFeaturedProducts: (featuredProductsFromRedux) =>
     dispatch(
       fetchProductCollectionAction(

--- a/src/Layout/Layout.js
+++ b/src/Layout/Layout.js
@@ -63,12 +63,17 @@ const Layout = ({
   }
 
   // if products haven't been fetched, fetch them
-  if (!onlineStore.length) {
+  if (
+      !onlineStore.length || 
+      !featuredProducts.length || 
+      !wholesaleProducts.length || 
+      !articles.length
+    ) {
     // populate state with products and articles from shopify
-    fetchOnlineStoreCollection();
-    fetchFeaturedProducts();
-    fetchWholesaleStoreCollection();
-    fetchShopifyArticles();
+      fetchOnlineStoreCollection();
+      fetchFeaturedProducts();
+      fetchWholesaleStoreCollection();
+      fetchShopifyArticles();
   }
 
   // if 5 minutes passed and it's not the initial page load,
@@ -113,6 +118,7 @@ const mapStateToProps = ({
   checkoutId,
   onlineStore,
   featuredProducts,
+  wholesaleProducts,
   articles,
   lastShopifyFetchTimestamp
 });

--- a/src/SharedComponents/FeaturedProducts.js
+++ b/src/SharedComponents/FeaturedProducts.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useLocation } from 'react-router-dom';
 import styled from "styled-components";
 import PropTypes from "prop-types";
 import ComponentWrapper from "./ComponentWrapper";
@@ -36,25 +36,29 @@ const ExploreShopLink = styled(Link)`
   }
 `;
 
-const Products = ({featuredProducts, title, hasTopBottomBorders}) => {
+const Products = ({featuredProducts, wholesaleProducts, title, hasTopBottomBorders}) => {
+
+  const location = useLocation();
+  const products = location.pathname.includes("wholesale") ? wholesaleProducts : featuredProducts;
 
   return (
     <ComponentWrapper hasTopBottomBorders={hasTopBottomBorders}>
       <StyledH2> {title} </StyledH2>
       <ProductsContainer>
-        {featuredProducts ? 
-          featuredProducts
-            .map(product => (
+        {featuredProducts
+          ? products.map((product) => (
               <Product key={product.id} product={product} />
-            )) : null}
+            ))
+          : null}
       </ProductsContainer>
       <ExploreShopLink to="/shop">Explore the Shop</ExploreShopLink>
     </ComponentWrapper>
   );
 };
 
-const mapStateToProps = ( {featuredProducts} ) => ({
-  featuredProducts
+const mapStateToProps = ( {featuredProducts, wholesaleProducts} ) => ({
+  featuredProducts,
+  wholesaleProducts
 });
 
 Products.propTypes = {

--- a/src/SharedComponents/FeaturedProducts.js
+++ b/src/SharedComponents/FeaturedProducts.js
@@ -45,7 +45,7 @@ const Products = ({featuredProducts, title, hasTopBottomBorders}) => {
         {featuredProducts ? 
           featuredProducts
             .map(product => (
-              <Product key={product.node.id} product={product.node} />
+              <Product key={product.id} product={product} />
             )) : null}
       </ProductsContainer>
       <ExploreShopLink to="/shop">Explore the Shop</ExploreShopLink>

--- a/src/pages/Product/Product.js
+++ b/src/pages/Product/Product.js
@@ -9,7 +9,7 @@ import Footer from "../../SharedComponents/Footer";
 
 // begin component
 const Product = ({
-  products,
+  onlineStore,
   match,
   checkout,
 }) => {
@@ -17,7 +17,7 @@ const Product = ({
   const { handle } = match.params;
 
   // select the current product
-  const selectProduct = products.filter(
+  const selectProduct = onlineStore.filter(
     product => handle === product.handle
   );
   const selectedProduct = selectProduct[0];
@@ -59,8 +59,8 @@ Product.propTypes = {
   checkout: PropTypes.object,
 };
 
-const mapStateToProps = ({products, checkout}) => ({
-  products,
+const mapStateToProps = ({onlineStore, checkout}) => ({
+  onlineStore,
   checkout,
 });
 

--- a/src/pages/Product/Product.js
+++ b/src/pages/Product/Product.js
@@ -17,6 +17,7 @@ const Product = ({
 
   const { handle } = match.params;
 
+  // determine if wholesaleProducts or onlineProducts should be loaded
   const products = handle.includes("wholesale") ? wholesaleProducts : onlineStore;
 
   // select the current product

--- a/src/pages/Product/Product.js
+++ b/src/pages/Product/Product.js
@@ -19,8 +19,6 @@ const Product = ({
 
   const products = handle.includes("wholesale") ? wholesaleProducts : onlineStore;
 
-  console.log(handle.includes("wholesale"));
-
   // select the current product
   const selectProduct = products.filter((product) => handle === product.handle);
   const selectedProduct = selectProduct[0];
@@ -43,7 +41,10 @@ const Product = ({
           doesItemExist={handleIfItemExists}
         />
         <Reviews />
-        <FeaturedProducts title={"More Products"} />
+        <FeaturedProducts title={products === wholesaleProducts ? 
+          "More Wholesale Products" : 
+          "More Products"
+        } />
       </div>
     ) : null
   }

--- a/src/pages/Product/Product.js
+++ b/src/pages/Product/Product.js
@@ -10,16 +10,19 @@ import Footer from "../../SharedComponents/Footer";
 // begin component
 const Product = ({
   onlineStore,
+  wholesaleProducts,
   match,
   checkout,
 }) => {
 
   const { handle } = match.params;
 
+  const products = handle.includes("wholesale") ? wholesaleProducts : onlineStore;
+
+  console.log(handle.includes("wholesale"));
+
   // select the current product
-  const selectProduct = onlineStore.filter(
-    product => handle === product.handle
-  );
+  const selectProduct = products.filter((product) => handle === product.handle);
   const selectedProduct = selectProduct[0];
 
   // check if item exists in checkout already
@@ -45,6 +48,8 @@ const Product = ({
     ) : null
   }
   
+  console.log(match);
+
   // begin component's return
   return (
     <PageWrapper>
@@ -59,8 +64,9 @@ Product.propTypes = {
   checkout: PropTypes.object,
 };
 
-const mapStateToProps = ({onlineStore, checkout}) => ({
+const mapStateToProps = ({onlineStore, wholesaleProducts, checkout}) => ({
   onlineStore,
+  wholesaleProducts,
   checkout,
 });
 

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -16,30 +16,13 @@ const ProductsContainer = styled.div`
   margin: 70px 0;
 `;
 
-
 const Shop = ({onlineStore}) => {
-
-  // copy prodcuts and sort diffuser to end of array
-  const sortDiffuserToEnd = [...onlineStore].sort((a,b) => 
-    a.title.includes("&") 
-      ? 0
-      : -1
-  );
-
-  // then sort unavailable onlineStore to very end of array
-  const sortedAvailableOnlineStore = [...sortDiffuserToEnd].sort((a, b) =>
-    a.availableForSale === b.availableForSale
-      ? 0
-      : a.availableForSale
-      ? -1
-      : 1
-  );
 
   return (
     <PageWrapper>
       <StyledH1>Shop</StyledH1>
       <ProductsContainer>
-        {sortedAvailableOnlineStore.map((product) => (
+        {onlineStore.map((product) => (
           <ShopProduct key={product.id} product={product} />
         ))}
       </ProductsContainer>
@@ -50,6 +33,6 @@ const Shop = ({onlineStore}) => {
 
 const mapStatetoProps = ({onlineStore}) => ({
   onlineStore
-})
+});
 
 export default connect(mapStatetoProps)(Shop);

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -16,13 +16,15 @@ const ProductsContainer = styled.div`
   margin: 70px 0;
 `;
 
-const Shop = ({onlineStore}) => {
+const Shop = ({onlineStore, wholesaleStore}) => {
+  const location = useLocation();
+  const products = location.pathname === '/shop' ? onlineStore : wholesaleStore;
 
   return (
     <PageWrapper>
-      <StyledH1>Shop</StyledH1>
+      <StyledH1>{location.pathname === '/shop' ? "Shop" : "Wholesale Shop" }</StyledH1>
       <ProductsContainer>
-        {onlineStore.map((product) => (
+        {products.map((product) => (
           <ShopProduct key={product.id} product={product} />
         ))}
       </ProductsContainer>
@@ -31,8 +33,9 @@ const Shop = ({onlineStore}) => {
   );
 };
 
-const mapStatetoProps = ({onlineStore}) => ({
-  onlineStore
+const mapStatetoProps = ({onlineStore, wholesaleStore}) => ({
+  onlineStore,
+  wholesaleStore
 });
 
 export default connect(mapStatetoProps)(Shop);

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { connect } from 'react-redux';
+import { useLocation } from 'react-router-dom';
 import styled from "styled-components";
 import PageWrapper from "../../SharedComponents/PageWrapper";
 import ShopProduct from "./ShopProduct";
@@ -14,6 +15,7 @@ const ProductsContainer = styled.div`
   position: relative;
   margin: 70px 0;
 `;
+
 
 const Shop = ({products}) => {
 

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -18,6 +18,8 @@ const ProductsContainer = styled.div`
 
 const Shop = ({onlineStore, wholesaleProducts}) => {
   const location = useLocation();
+  
+  // determine if onlineStore or wholesaleProducts should be loaded;
   const products =
     location.pathname === "/shop" ? onlineStore : wholesaleProducts;
 

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -17,17 +17,17 @@ const ProductsContainer = styled.div`
 `;
 
 
-const Shop = ({products}) => {
+const Shop = ({onlineStore}) => {
 
   // copy prodcuts and sort diffuser to end of array
-  const sortDiffuserToEnd = [...products].sort((a,b) => 
+  const sortDiffuserToEnd = [...onlineStore].sort((a,b) => 
     a.title.includes("&") 
       ? 0
       : -1
   );
 
-  // then sort unavailable products to very end of array
-  const sortedAvailableProducts = [...sortDiffuserToEnd].sort((a, b) =>
+  // then sort unavailable onlineStore to very end of array
+  const sortedAvailableOnlineStore = [...sortDiffuserToEnd].sort((a, b) =>
     a.availableForSale === b.availableForSale
       ? 0
       : a.availableForSale
@@ -37,22 +37,19 @@ const Shop = ({products}) => {
 
   return (
     <PageWrapper>
-      <StyledH1>
-        Shop
-      </StyledH1>
+      <StyledH1>Shop</StyledH1>
       <ProductsContainer>
-        {sortedAvailableProducts
-          .map(product => (
-            <ShopProduct key={product.id} product={product} />
-          ))}
+        {sortedAvailableOnlineStore.map((product) => (
+          <ShopProduct key={product.id} product={product} />
+        ))}
       </ProductsContainer>
       <Footer />
     </PageWrapper>
   );
 };
 
-const mapStatetoProps = ({products}) => ({
-  products
+const mapStatetoProps = ({onlineStore}) => ({
+  onlineStore
 })
 
 export default connect(mapStatetoProps)(Shop);

--- a/src/pages/Shop/Shop.js
+++ b/src/pages/Shop/Shop.js
@@ -16,9 +16,10 @@ const ProductsContainer = styled.div`
   margin: 70px 0;
 `;
 
-const Shop = ({onlineStore, wholesaleStore}) => {
+const Shop = ({onlineStore, wholesaleProducts}) => {
   const location = useLocation();
-  const products = location.pathname === '/shop' ? onlineStore : wholesaleStore;
+  const products =
+    location.pathname === "/shop" ? onlineStore : wholesaleProducts;
 
   return (
     <PageWrapper>
@@ -33,9 +34,9 @@ const Shop = ({onlineStore, wholesaleStore}) => {
   );
 };
 
-const mapStatetoProps = ({onlineStore, wholesaleStore}) => ({
+const mapStatetoProps = ({onlineStore, wholesaleProducts}) => ({
   onlineStore,
-  wholesaleStore
+  wholesaleProducts
 });
 
 export default connect(mapStatetoProps)(Shop);

--- a/src/pages/Shop/ShopProduct.js
+++ b/src/pages/Shop/ShopProduct.js
@@ -101,6 +101,7 @@ const createProduct = (product, clearHeroImg, updateQuantityButton) => {
 
 // begin component
 const ShopProduct = ({location: {pathname}, product, clearHeroImg, updateQuantityButton}) => {
+  
   return (
     <ProductContainer pathname={pathname}>
       {createProduct(product, clearHeroImg, updateQuantityButton)}

--- a/src/state/actions/cart.js
+++ b/src/state/actions/cart.js
@@ -13,11 +13,11 @@ export const removeLineItem = (productId, index) => ({
 });
 
 export const updateItemQuantity = (quantityToUpdate, shouldAddQuantities, product) => ({
-         type: CartActionTypes.UPDATE_ITEM_QUANTITY,
-         quantityToUpdate,
-         shouldAddQuantities,
-         product
-       });
+  type: CartActionTypes.UPDATE_ITEM_QUANTITY,
+  quantityToUpdate,
+  shouldAddQuantities,
+  product
+});
 
 export const updateCheckoutId = (id) => ({
   type: CartActionTypes.UPDATE_CHECKOUT_ID,
@@ -72,6 +72,6 @@ export const setGoogleMapInfoWindow = (selectedStoreName) => ({
 });
 
 export const updateShopifyFetchTimestamp = () => ({
-         type: CartActionTypes.UPDATE_SHOPIFY_FETCH_TIMESTAMP,
-         timestamp: Date.now()
-       });
+  type: CartActionTypes.UPDATE_SHOPIFY_FETCH_TIMESTAMP,
+  timestamp: Date.now()
+});

--- a/src/state/app.js
+++ b/src/state/app.js
@@ -5,7 +5,7 @@ export const initialState = {
     lineItems: [],
     checkoutId: '',
   },
-  products: [],
+  onlineStore: [],
   featuredProducts: [],
   articles: [],
   pending: true,

--- a/src/state/app.js
+++ b/src/state/app.js
@@ -6,6 +6,7 @@ export const initialState = {
     checkoutId: '',
   },
   onlineStore: [],
+  wholesaleProducts: [],
   featuredProducts: [],
   articles: [],
   pending: true,

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -124,6 +124,7 @@ export const queryCollection = (collectionHandle, numOfItems) => client.graphQLC
 );
 
 export const handleDispatchingProducts = (reduxKey, products, dispatch) => {
+    console.log(reduxKey, ":", products);
     // add products from collection to redux
     dispatch(fetchSuccess(reduxKey, products));
     // set timestamp in redux to show shopify data was fetched

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -191,11 +191,7 @@ export const queryCollection = (collectionHandle, numOfItems) => client.graphQLC
 // !!!!!!!!!
 // make both of these "handle" functions extensible by adding collectionHandle to params, 
 // then use conditional to use different dispatch based on if collectionHandle is "featured-products" or "wholesale-products"
-export const handleDispatchingFeaturedProducts = (collectionHandle, data, dispatch) => {
-  // take collectionHandle and format it as "featuredProducts" instead of something like "featured-products" for redux
-  const splitHandle = collectionHandle.split("-");
-  const reduxKey = splitHandle[0] + splitHandle[1][0].toUpperCase() + splitHandle[1].slice(1);
-
+export const handleDispatchingFeaturedProducts = (reduxKey, data, dispatch) => {
   const products = data.collectionByHandle.products.edges;
     // add products from collection to redux
     dispatch(fetchSuccess(reduxKey, products));
@@ -203,13 +199,13 @@ export const handleDispatchingFeaturedProducts = (collectionHandle, data, dispat
     dispatch(updateShopifyFetchTimestamp());
 };
 
-export const handleUpdatingFeaturedProducts = (collectionHandle, data, dispatch, featuredProductsFromRedux) => {
-  const featuredProducts = data.collectionByHandle.products.edges;
+export const handleUpdatingFeaturedProducts = (reduxKey, data, dispatch, featuredProductsFromRedux) => {
+  const products = data.collectionByHandle.products.edges;
   // check to see if featuredProducts in redux is the same as products from shopify
   // if not, add the featuredProducts to redux
-  return featuredProductsFromRedux === featuredProducts
+  return featuredProductsFromRedux === products
     ? null
-    : dispatch(fetchSuccess("featuredProducts", featuredProducts));
+    : dispatch(fetchSuccess(reduxKey, products));
 };
 
 // GET Featured-Products collection on initial page load
@@ -219,7 +215,11 @@ export const fetchProductCollectionAction = (collectionHandle, numOfItems, handl
     client.graphQLClient
       .send(queryCollection(collectionHandle, numOfItems))
       .then(({ model, data }) => {
-        handleReduxDispatch(collectionHandle, data, dispatch, collectionFromRedux);
+        // take collectionHandle and format it as "featuredProducts" instead of something like "featured-products" for redux
+        const splitHandle = collectionHandle.split("-");
+        const reduxKey = splitHandle[0] + splitHandle[1][0].toUpperCase() + splitHandle[1].slice(1);
+
+        handleReduxDispatch(reduxKey, data, dispatch, collectionFromRedux);
       })
       .catch((error) => {
         dispatch(fetchError(error));

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -64,71 +64,6 @@ export const updateShopifyArticlesAction = (articlesFromRedux) => {
   };
 };
 
-// PRODUCTS SECTION
-const productsQuery = client.graphQLClient.query(root => {
-  root.addConnection("products", { args: { first: 20 } }, product => {
-    product.add("title");
-    product.add("descriptionHtml");
-    product.add("handle");
-    product.add("availableForSale");
-    product.addConnection("metafields", { args: { first: 2 } }, metafield => {
-      metafield.add("key");
-      metafield.add("value");
-    });
-    product.addConnection("images", { args: { first: 10 } }, image => {
-      image.add("id");
-      image.add("src");
-      image.add("altText");
-    });
-    product.addConnection("variants", { args: { first: 1 } }, variant => {
-      variant.add("id");
-      variant.add("price");
-    });
-  });
-});
-
-// GET products on initial page load
-export const fetchShopifyProductsAction = () => {
-  return dispatch => {
-    dispatch(fetchPending());
-    // Call the send method with the custom products query
-    client.graphQLClient
-      .send(productsQuery)
-      .then(({ model, data }) => {
-        const products = data.products.edges.map(product => product.node);
-        // add products from shopify to redux
-        dispatch(fetchSuccess("products", products));
-        // set timestamp in redux to show shopify data was fetched
-        dispatch(updateShopifyFetchTimestamp());
-        return products;
-      })
-      .catch(error => {
-        dispatch(fetchError(error));
-      });
-  };
-};
-
-// UPDATE products
-export const updateShopifyProductsAction = productsFromRedux => {
-  return dispatch => {
-    dispatch(fetchPending());
-    // Call the send method with the custom products query
-    client.graphQLClient
-      .send(productsQuery)
-      .then(({ model, data }) => {
-        const products = data.products.edges.map(product => product.node);
-        // check to see if products in redux is the same as products from shopify
-        // if not, add the products to redux
-        return productsFromRedux === products
-          ? null
-          : dispatch(fetchSuccess("products", products));
-      })
-      .catch(error => {
-        dispatch(fetchError(error));
-      });
-  };
-};
-
 // "featured-products" COLLECTION SECTION
 // create variable to use sortKey
 const sortKey = client.graphQLClient.variable(
@@ -188,11 +123,7 @@ export const queryCollection = (collectionHandle, numOfItems) => client.graphQLC
   }
 );
 
-// !!!!!!!!!
-// make both of these "handle" functions extensible by adding collectionHandle to params, 
-// then use conditional to use different dispatch based on if collectionHandle is "featured-products" or "wholesale-products"
 export const handleDispatchingProducts = (reduxKey, products, dispatch) => {
-  console.log(products);
     // add products from collection to redux
     dispatch(fetchSuccess(reduxKey, products));
     // set timestamp in redux to show shopify data was fetched
@@ -227,40 +158,3 @@ export const fetchProductCollectionAction = (collectionHandle, numOfItems, handl
       });
   };
 };
-
-// UPDATE featured-products
-// export const updateCollectionAction = (, collectionHandle, numOfItems, handleReduxUpdate) => {
-//   return dispatch => {
-//     dispatch(fetchPending());
-//     // Call the send method with the custom products query
-//     client.graphQLClient
-//       .send(queryCollection(collectionHandle, numOfItems))
-//       .then(({ model, data }) => {
-//         handleReduxUpdate(data, dispatch, collectionFromRedux);
-//       })
-//       .catch(error => {
-//         dispatch(fetchError(error));
-//       });
-//   };
-// };
-
-// UPDATE featured-products
-// export const updateFeaturedProductsAction = featuredProductsFromRedux => {
-//   return dispatch => {
-//     dispatch(fetchPending());
-//     // Call the send method with the custom products query
-//     client.graphQLClient
-//       .send(queryFeaturedProductsCollection)
-//       .then(({ model, data }) => {
-//         const featuredProducts = data.collectionByHandle.products.edges;
-//         // check to see if featuredProducts in redux is the same as products from shopify
-//         // if not, add the featuredProducts to redux
-//         return featuredProductsFromRedux === featuredProducts
-//           ? null
-//           : dispatch(fetchSuccess("featuredProducts", featuredProducts));
-//       })
-//       .catch(error => {
-//         dispatch(fetchError(error));
-//       });
-//   };
-// };

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -6,7 +6,7 @@ import {
 } from "./actions/cart";
 import { client } from "../plugins/shopify.js";
 
-// Below are three sections: articles, products, and collections
+// Below are two sections: articles, and collections
 // In each section there are three peices: a query, the method to fetch data on initial load, 
 // and the method to update data if it is different than what's in redux
 
@@ -71,7 +71,6 @@ const sortKey = client.graphQLClient.variable(
   "ProductCollectionSortKeys"
 );
 
-
 export const queryCollection = (collectionHandle, numOfItems) => client.graphQLClient.query(
   [sortKey],
   root => {
@@ -124,22 +123,21 @@ export const queryCollection = (collectionHandle, numOfItems) => client.graphQLC
 );
 
 export const handleDispatchingProducts = (reduxKey, products, dispatch) => {
-    console.log(reduxKey, ":", products);
     // add products from collection to redux
     dispatch(fetchSuccess(reduxKey, products));
     // set timestamp in redux to show shopify data was fetched
     dispatch(updateShopifyFetchTimestamp());
 };
 
-export const handleUpdatingProducts = (reduxKey, products, dispatch, featuredProductsFromRedux) => {
-  // check to see if featuredProducts in redux is the same as products from shopify
-  // if not, add the featuredProducts to redux
-  return featuredProductsFromRedux === products
+export const handleUpdatingProducts = (reduxKey, products, dispatch, productsFromRedux) => {
+  // check to see if products in redux is the same as products from shopify
+  // if not, add the products to redux
+  return productsFromRedux === products
     ? null
     : dispatch(fetchSuccess(reduxKey, products));
 };
 
-// GET Featured-Products collection on initial page load
+// GET a product collection on initial page load
 export const fetchProductCollectionAction = (collectionHandle, numOfItems, handleReduxDispatch, collectionFromRedux) => {
   return dispatch => {
     dispatch(fetchPending()); 

--- a/src/state/fetchShopifyData.js
+++ b/src/state/fetchShopifyData.js
@@ -191,16 +191,15 @@ export const queryCollection = (collectionHandle, numOfItems) => client.graphQLC
 // !!!!!!!!!
 // make both of these "handle" functions extensible by adding collectionHandle to params, 
 // then use conditional to use different dispatch based on if collectionHandle is "featured-products" or "wholesale-products"
-export const handleDispatchingFeaturedProducts = (reduxKey, data, dispatch) => {
-  const products = data.collectionByHandle.products.edges;
+export const handleDispatchingProducts = (reduxKey, products, dispatch) => {
+  console.log(products);
     // add products from collection to redux
     dispatch(fetchSuccess(reduxKey, products));
     // set timestamp in redux to show shopify data was fetched
     dispatch(updateShopifyFetchTimestamp());
 };
 
-export const handleUpdatingFeaturedProducts = (reduxKey, data, dispatch, featuredProductsFromRedux) => {
-  const products = data.collectionByHandle.products.edges;
+export const handleUpdatingProducts = (reduxKey, products, dispatch, featuredProductsFromRedux) => {
   // check to see if featuredProducts in redux is the same as products from shopify
   // if not, add the featuredProducts to redux
   return featuredProductsFromRedux === products
@@ -215,11 +214,13 @@ export const fetchProductCollectionAction = (collectionHandle, numOfItems, handl
     client.graphQLClient
       .send(queryCollection(collectionHandle, numOfItems))
       .then(({ model, data }) => {
+        // get product nodes
+        const products = data.collectionByHandle.products.edges.map(product => product.node);
         // take collectionHandle and format it as "featuredProducts" instead of something like "featured-products" for redux
         const splitHandle = collectionHandle.split("-");
         const reduxKey = splitHandle[0] + splitHandle[1][0].toUpperCase() + splitHandle[1].slice(1);
 
-        handleReduxDispatch(reduxKey, data, dispatch, collectionFromRedux);
+        handleReduxDispatch(reduxKey, products, dispatch, collectionFromRedux);
       })
       .catch((error) => {
         dispatch(fetchError(error));


### PR DESCRIPTION
# Purpose
- create route /wholesale so that wholesalers could see a list of products that are only available for wholesale
- remove wholesale items from /shop
- refactor fetchShopifyData to extend functionality for fetching different types of collections
- refactor products to onlineStore, which uses online-store collection in shopify

# Validating
Ensure that all previous product-related behavior still works as expected after clearing localState:
- loading pages for home, shop, checkout, an individual product, an individual recipe results in featuredProducts being loaded
- loading an individual product works as expected
- loading /shop shows only items in online-store collection in shopify
- loading /warehouse shows only warehouse items
- loading a warehouse product shows warehouse product details
- loading warehouse product shows warehouse products in featuredProducts component
- warehouse products have a maxQuantity of 10
- checking out works as expected for warehouse products, online-store products, and with a checkout that is a mix of both

# Background Context
- whidbey herbal needs a way to allow wholesalers to make larger orders than general public customers
- general public should not be able to easily find /wholesale items

# Follow-On Questions
- may be a good idea to add some kind of validation to any path that contains "wholesale", ensuring that even if someone from the public found wholesale information, they wouldn't be able to access those items

# Extra Release Steps
- none